### PR TITLE
Don't capture keys in html:textarea elements

### DIFF
--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -109,6 +109,7 @@ var TBKeys = {
                 tagName == 'textbox' || tagName == 'input' ||
                 tagName == 'select' || tagName == 'textarea' ||
                 tagName == 'html:input' || tagName == 'search-textbox' ||
+                tagName == 'hmtl:textarea' ||
                 (element.contentEditable && element.contentEditable == 'true')
             )
 


### PR DESCRIPTION
Closes #53.