### PR TITLE
Use ExtensionSupport to load Mousetrap and retry storage.local.get() on failure

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -72,8 +72,8 @@ async function getSettings() {
 async function applyKeys() {
     let settings = await getSettings()
 
-    browser.tbkeys.bindkeys(JSON.parse(settings.mainkeys), "main")
-    browser.tbkeys.bindkeys(JSON.parse(settings.composekeys), "compose")
+    await browser.tbkeys.bindkeys(JSON.parse(settings.mainkeys), "main")
+    await browser.tbkeys.bindkeys(JSON.parse(settings.composekeys), "compose")
 }
 
 applyKeys()


### PR DESCRIPTION
Avoids inconsistent behavior due to tbkeys trying to load into a
half-loaded window.

Closes #52.