### PR TITLE
Set max version for tbkeys-lite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ $(BLDDIR)/tbkeys-lite.xpi: $(SRC_FILES)
 	cp -r addon $(dir $@)/lite
 	# Drop update_url
 	sed -i '/update_url/d' $(dir $@)/lite/manifest.json
-	sed -i 's/\( *"strict_min_version".*\),$$/\1/' $(dir $@)/lite/manifest.json
+	sed -i 's/\( *"strict_min_version".*\),$$/\1,/' $(dir $@)/lite/manifest.json
+	sed -i 's/\( *"strict_max_version": \)\(.*\),$$/\1"103.0"/' $(dir $@)/lite/manifest.json
 	# Drop eval()
 	sed -i 's#^\( *\)eval(.*#\1// Do nothing#' $(dir $@)/lite/implementation.js
 	# Change name

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -4,6 +4,7 @@
     "gecko": {
       "id": "tbkeys@addons.thunderbird.net",
       "strict_min_version": "68.0",
+      "strict_max_version": "*",
       "update_url": "https://raw.githubusercontent.com/wshanks/tbkeys/main/updates.json"
     }
   },


### PR DESCRIPTION
Set to current highest version number (which was also tested to work
with tbkeys).

Follow up to #101.