### PR TITLE
Mark tbkeys-lite max Thunderbird version as 102.*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(BLDDIR)/tbkeys-lite.xpi: $(SRC_FILES)
 	# Drop update_url
 	sed -i '/update_url/d' $(dir $@)/lite/manifest.json
 	sed -i 's/\( *"strict_min_version".*\),$$/\1,/' $(dir $@)/lite/manifest.json
-	sed -i 's/\( *"strict_max_version": \)\(.*\),$$/\1"103.0"/' $(dir $@)/lite/manifest.json
+	sed -i 's/\( *"strict_max_version": \)\(.*\),$$/\1"102.*"/' $(dir $@)/lite/manifest.json
 	# Drop eval()
 	sed -i 's#^\( *\)eval(.*#\1// Do nothing#' $(dir $@)/lite/implementation.js
 	# Change name


### PR DESCRIPTION
Per request of addons.thunderbird.net reviewer not to set the version to an intermediate beta