### PR TITLE
Disable shortcuts in new search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2.2.3b1:
+
+  - Do not capture kesy in the search box of Thunderbird 113+
+
 - 2.2.2:
 
   - Mark tbkeys-lite as supporting Thunderbird 102.\* instead of 103.0.

--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -53,6 +53,7 @@ function stopCallback(e, element, combo, seq) {
     tagName == "search-textbox" ||
     tagName == "html:textarea" ||
     tagName == "browser" ||
+    tagName == "global-search-bar" ||
     (element.contentEditable && element.contentEditable == "true");
 
   if (!isText && element.contentEditable == "inherit") {


### PR DESCRIPTION
This fixes issue #131 and in turn a part of #138. Only addition is adding a new tag where shortcuts are ignored.