### PR TITLE
Use Services global variable if possible

### DIFF
--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -10,7 +10,9 @@ var { ExtensionParent } = ChromeUtils.import(
 var { ExtensionSupport } = ChromeUtils.import(
   "resource:///modules/ExtensionSupport.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 const EXTENSION_NAME = "tbkeys@addons.thunderbird.net";
 var extension = ExtensionParent.GlobalManager.getExtension(EXTENSION_NAME);


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.