### PR TITLE
Change tag name for quick filter input to match Thunderbird 115+

### DIFF
--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -52,7 +52,7 @@ function stopCallback(e, element, combo, seq) {
     tagName == "select" ||
     tagName == "textarea" ||
     tagName == "html:input" ||
-    tagName == "search-textbox" ||
+    tagName == "xul:search-textbox" ||
     tagName == "html:textarea" ||
     tagName == "browser" ||
     tagName == "global-search-bar" ||


### PR DESCRIPTION
This fixes #146, although very lazily. If you'd prefer to keep the old tag name in (without the `xul:` prefix), I can also re-add that. Only tested this real quick on my end, and it works.