### PR TITLE
Treat QuickSearch box as text input in Thunderbird 128

### DIFF
--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -57,6 +57,7 @@ function stopCallback(e, element, combo, seq) {
     tagName == "html:textarea" ||
     tagName == "browser" ||
     tagName == "global-search-bar" ||
+    tagName == "search-bar" ||
     (element.contentEditable && element.contentEditable == "true");
 
   if (!isText && element.contentEditable == "inherit") {


### PR DESCRIPTION
This box changed names once again. It would be nice to have a more reliable way of detecting text inputs.