### PR TITLE
Temporarily remove version 2.3.0 from the update list

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -64,10 +64,6 @@
         {
           "version": "2.2.5",
           "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.2.5/tbkeys.xpi"
-        },
-        {
-          "version": "2.3.0",
-          "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.3.0/tbkeys.xpi"
         }
       ]
     }


### PR DESCRIPTION
This version is not marking itself as incompatible with older Thunderbird versions so they are updating to it and finding the add-on disabled.