### PR TITLE
Set minimum Thunderbird version in updates.json

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -64,6 +64,13 @@
         {
           "version": "2.2.5",
           "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.2.5/tbkeys.xpi"
+        },
+        {
+          "version": "2.3.0",
+          "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.3.0/tbkeys.xpi",
+          "browser_specific_settings": {
+            "gecko": { "strict_min_version": "115" }
+          }
         }
       ]
     }


### PR DESCRIPTION
This setting prevents older versions of Thunderbird from installing the newer versions of tbkeys that are marked as not compatible. Without this setting, Thunderbird will install the new version and then disable it because its manifest specifies it as not compatible.