### PR TITLE
Address compatibility with Thunderbird 136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- 2.4.0:
+
+  - Drop support for versions of Thunderbird older than 128 and fix compatibility with Thunderbird 136.
+    Those versions can continue using 2.3.0.
+
 - 2.3.0:
 
   - Drop support for versions of Thunderbird older than 115.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(BLDDIR)/tbkeys-lite.xpi: $(SRC_FILES)
 	# Drop update_url
 	sed -i '/update_url/d' $(dir $@)/lite/manifest.json
 	sed -i 's/\( *"strict_min_version".*\),$$/\1,/' $(dir $@)/lite/manifest.json
-	sed -i 's/\( *"strict_max_version": \)\(.*\),$$/\1"130.*"/' $(dir $@)/lite/manifest.json
+	sed -i 's/\( *"strict_max_version": \)\(.*\),$$/\1"136.*"/' $(dir $@)/lite/manifest.json
 	# Drop eval()
 	sed -i 's#^\( *\)eval(.*#\1// Do nothing#' $(dir $@)/lite/implementation.js
 	# Change name

--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -1,14 +1,14 @@
 "use strict";
 /* global ChromeUtils, Services */
 
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
+var { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
 );
-var { ExtensionParent } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionParent.jsm"
+var { ExtensionParent } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionParent.sys.mjs"
 );
-var { ExtensionSupport } = ChromeUtils.import(
-  "resource:///modules/ExtensionSupport.jsm"
+var { ExtensionSupport } = ChromeUtils.importESModule(
+  "resource:///modules/ExtensionSupport.sys.mjs"
 );
 
 const EXTENSION_NAME = "tbkeys@addons.thunderbird.net";

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -3,7 +3,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "tbkeys@addons.thunderbird.net",
-      "strict_min_version": "115.0",
+      "strict_min_version": "128.0",
       "strict_max_version": "*",
       "update_url": "https://raw.githubusercontent.com/wshanks/tbkeys/main/updates.json"
     }


### PR DESCRIPTION
As pointed out by https://github.com/wshanks/tbkeys/issues/199, Thunderbird 128 updated its JSM modules to be ES6 modules, requiring them to be imported with `importESModule` instead of `import`. Backwards compatibility shims kept these imports working, but with Thunderbird 136 the shims are removed. In the change here, tbkeys is updated to use `importESModule` which works for Thunderbird 128+. Older versions of Thunderbird can keep using the previous release of tbekys.

Closes https://github.com/wshanks/tbkeys/issues/199