### PR TITLE
Fix key updates.json so minimum Thunderbird version is respected

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -68,14 +68,14 @@
         {
           "version": "2.3.0",
           "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.3.0/tbkeys.xpi",
-          "browser_specific_settings": {
+          "applications": {
             "gecko": { "strict_min_version": "115.0" }
           }
         },
         {
           "version": "2.4.0",
           "update_link": "https://github.com/wshanks/tbkeys/releases/download/v2.4.0/tbkeys.xpi",
-          "browser_specific_settings": {
+          "applications": {
             "gecko": { "strict_min_version": "128.0" }
           }
         }


### PR DESCRIPTION
The key should be `applications` and not `browser_specific_settings` according to:

* https://thunderbird.topicbox.com/groups/addons/Tc62ea62472ef83e1/how-to-prevent-an-incompatible-update-for-an-older-thunderbird
* https://github.com/jobisoft/github-based-release-example/blob/a4d20eaefc4aa6ed0cf47611f15e54d87f0f5ad5/update.json