### PR TITLE
Support array-based key bindings (execute multiple commands)

### DIFF
--- a/addon/schema.json
+++ b/addon/schema.json
@@ -46,7 +46,7 @@
         "id": "Keys",
         "type": "object",
         "description": "Mapping of key sequences to commands",
-        "additionalProperties": { "type": "string" }
+        "additionalProperties": { "type": "any" }
       }
     ]
   }


### PR DESCRIPTION
Hi, thanks for the great addon.

I found that using an array for key bindings (e.g., `["cmd:A", "cmd:B"]`) was causing errors due to schema validation and implementation logic.

I have updated `implementation.js` and `schema.json` to support array-based commands properly.
This allows users to execute multiple commands with a single key press (e.g., Mark as Read -> Archive).

Please review the changes. Thanks!